### PR TITLE
feat(exec): use one string instead of string array

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.6
+FROM golang:1.7
 
 RUN wget http://storage.googleapis.com/kubernetes-release/release/v1.7.2/bin/linux/amd64/kubectl -O /usr/bin/kubectl && \
     chmod +x /usr/bin/kubectl
@@ -9,6 +9,7 @@ WORKDIR /go/src/app
 ADD . /go/src/app/
 
 RUN go-wrapper download
+RUN cd /go/src/github.com/nlopes/slack && git checkout tags/v0.4.0
 RUN go-wrapper install
 
 CMD ["app"]

--- a/execute.go
+++ b/execute.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"strings"
 )
 
 func execute(name string, arg ...string) string {
@@ -13,7 +14,8 @@ func execute(name string, arg ...string) string {
 	os.Stdout = w
 	os.Stderr = w
 
-	cmd := exec.Command(name, arg...)
+	command := fmt.Sprintf("%s %s", name, strings.Join(arg, " "))
+	cmd := exec.Command("bash", "-c", command)
 
 	stdin, err := cmd.StdinPipe()
 

--- a/kubebot.yaml
+++ b/kubebot.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: kubebot
-        image: harbur/kubebot:0.1.0
+        image: gcr.io/internaltools-184612/kubebot:latest
         imagePullPolicy: Always
         env:
         # Create a secret with your slack bot token and reference it here


### PR DESCRIPTION
Minimum Viable Change : 

I've kept the `command.Args` argument in order to avoid to break checks on this array. We just concatenate this array into a string when we call `exec.Command`.

Tested with : `cat /etc/resolv.conf | grep nameserver`  